### PR TITLE
Minor Bug Fixes...

### DIFF
--- a/App/customElements.py
+++ b/App/customElements.py
@@ -183,6 +183,7 @@ class ExportWindow(tk.Frame):
         for item in self.root.selected:
             itemPath = self.exportPath
             if self.keepHierarchy.get():
+                itemPath = os.path.join(itemPath, item.fullPath)
                 itemPath += item.fullPath
             # Save the item.
             if isinstance(item, FileItem):

--- a/App/fileSys.py
+++ b/App/fileSys.py
@@ -3,10 +3,13 @@ import os
 
 def _cleanPath(filepath: str):
     # I have no clue if this will work...
-    illegalChars = "<>:\"|?*"
-    for char in illegalChars:
-        filepath = filepath.replace(char, "")
-    return filepath
+    # How do I handle Window's C:/?
+    # illegalChars = "<>:\"|?*"
+    # Okay here's the plan... We let individuals enter in bad filepaths, and treat that as user error and thereby avoidable.
+    # I'll just focus on handling CCP's strange choice of using "res:"
+    # for char in illegalChars:
+    #     filepath = filepath.replace(char, "")
+    return filepath.replace("res:", "res")
 
 
 class FileDir:


### PR DESCRIPTION
Some minor bug fixes.

Behavior with exporting file paths that keep their hierarchy has been fixed on windows (no more "res:" causing problems).

Can now export OBJs to file paths that contained folders with spaces (I forgot some quotation marks when calling Tamber's tool).

Gave up on trying to keep illegal characters out of the file path. Just don't do that, it won't work, and I am filing it under "user error".

There is now some weird behavior when exporting the contents of a folder by selecting that folder (it doubles up that one folder in the hierarchy like this: /stuff/ship/ship/morestuff/). I'll fix that later but it's late and I want to sleep ;_;